### PR TITLE
Retrieving Mvn version, dependency fixes, and small improvements

### DIFF
--- a/jdk_11_gradle/build.gradle
+++ b/jdk_11_gradle/build.gradle
@@ -1,6 +1,6 @@
 
 allprojects {
     ext {
-        EVOMASTER_VERSION = "3.1.0"
+        EVOMASTER_VERSION = "3.1.1-SNAPSHOT"
     }
 }

--- a/jdk_11_maven/cs/graphql/pom.xml
+++ b/jdk_11_maven/cs/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-cs-graphql</artifactId>

--- a/jdk_11_maven/cs/pom.xml
+++ b/jdk_11_maven/cs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-cs</artifactId>

--- a/jdk_11_maven/cs/rest-gui/pom.xml
+++ b/jdk_11_maven/cs/rest-gui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-cs-rest-gui</artifactId>

--- a/jdk_11_maven/cs/rest/pom.xml
+++ b/jdk_11_maven/cs/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-cs-rest</artifactId>

--- a/jdk_11_maven/em/embedded/graphql/pom.xml
+++ b/jdk_11_maven/em/embedded/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-embedded-graphql</artifactId>

--- a/jdk_11_maven/em/embedded/graphql/timbuctoo/pom.xml
+++ b/jdk_11_maven/em/embedded/graphql/timbuctoo/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded-graphql</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jdk_11_maven/em/embedded/pom.xml
+++ b/jdk_11_maven/em/embedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-embedded</artifactId>

--- a/jdk_11_maven/em/embedded/rest/cwa-verification/pom.xml
+++ b/jdk_11_maven/em/embedded/rest/cwa-verification/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_11_maven/em/embedded/rest/market/pom.xml
+++ b/jdk_11_maven/em/embedded/rest/market/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_11_maven/em/embedded/rest/pay-publicapi/pom.xml
+++ b/jdk_11_maven/em/embedded/rest/pay-publicapi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-embedded-rest-pay-publicapi</artifactId>

--- a/jdk_11_maven/em/embedded/rest/pom.xml
+++ b/jdk_11_maven/em/embedded/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-embedded-rest</artifactId>

--- a/jdk_11_maven/em/external/graphql/pom.xml
+++ b/jdk_11_maven/em/external/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-external-graphql</artifactId>

--- a/jdk_11_maven/em/external/graphql/timbuctoo/pom.xml
+++ b/jdk_11_maven/em/external/graphql/timbuctoo/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external-graphql</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_11_maven/em/external/pom.xml
+++ b/jdk_11_maven/em/external/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-external</artifactId>

--- a/jdk_11_maven/em/external/rest/cwa-verification/pom.xml
+++ b/jdk_11_maven/em/external/rest/cwa-verification/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_11_maven/em/external/rest/ind1/pom.xml
+++ b/jdk_11_maven/em/external/rest/ind1/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_11_maven/em/external/rest/market/pom.xml
+++ b/jdk_11_maven/em/external/rest/market/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_11_maven/em/external/rest/pay-publicapi/pom.xml
+++ b/jdk_11_maven/em/external/rest/pay-publicapi/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_11_maven/em/external/rest/pom.xml
+++ b/jdk_11_maven/em/external/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em-external-rest</artifactId>

--- a/jdk_11_maven/em/pom.xml
+++ b/jdk_11_maven/em/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk11</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk11-em</artifactId>

--- a/jdk_11_maven/pom.xml
+++ b/jdk_11_maven/pom.xml
@@ -9,7 +9,7 @@
         To change version in all modules, use:
         mvn versions:set -DnewVersion=a.b.c
      -->
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <inceptionYear>2017</inceptionYear>
     <name>EvoMaster Benchmark (EMB)</name>
@@ -47,7 +47,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <evomaster-version>3.1.0</evomaster-version>
+        <evomaster-version>3.1.1-SNAPSHOT</evomaster-version>
     </properties>
 
     <build>

--- a/jdk_17_gradle/build.gradle
+++ b/jdk_17_gradle/build.gradle
@@ -1,6 +1,6 @@
 
 allprojects {
     ext {
-        EVOMASTER_VERSION = "3.1.0"
+        EVOMASTER_VERSION = "3.1.1-SNAPSHOT"
     }
 }

--- a/jdk_17_maven/cs/grpc/pom.xml
+++ b/jdk_17_maven/cs/grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-cs-grpc</artifactId>

--- a/jdk_17_maven/cs/pom.xml
+++ b/jdk_17_maven/cs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-cs</artifactId>

--- a/jdk_17_maven/cs/rest/familie-ba-sak/pom.xml
+++ b/jdk_17_maven/cs/rest/familie-ba-sak/pom.xml
@@ -392,6 +392,10 @@
             <id>github</id>
             <url>https://maven.pkg.github.com/navikt/familie-felles</url>
         </repository>
+        <repository>
+            <id>familie</id>
+            <url>https://github-package-registry-mirror.gc.nav.no/cached/maven-release</url>
+        </repository>
     </repositories>
 
 

--- a/jdk_17_maven/cs/rest/pom.xml
+++ b/jdk_17_maven/cs/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-cs-rest</artifactId>

--- a/jdk_17_maven/cs/web/pom.xml
+++ b/jdk_17_maven/cs/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-cs-web</artifactId>

--- a/jdk_17_maven/em/embedded/grpc/pom.xml
+++ b/jdk_17_maven/em/embedded/grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-embedded-grpc</artifactId>

--- a/jdk_17_maven/em/embedded/grpc/signal-registration/pom.xml
+++ b/jdk_17_maven/em/embedded/grpc/signal-registration/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_17_maven/em/embedded/pom.xml
+++ b/jdk_17_maven/em/embedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-embedded</artifactId>

--- a/jdk_17_maven/em/embedded/rest/familie-ba-sak/pom.xml
+++ b/jdk_17_maven/em/embedded/rest/familie-ba-sak/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-embedded-rest-familie-ba-sak</artifactId>

--- a/jdk_17_maven/em/embedded/rest/pom.xml
+++ b/jdk_17_maven/em/embedded/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-embedded-rest</artifactId>

--- a/jdk_17_maven/em/embedded/web/pom.xml
+++ b/jdk_17_maven/em/embedded/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-embedded-web</artifactId>

--- a/jdk_17_maven/em/embedded/web/spring-petclinic/pom.xml
+++ b/jdk_17_maven/em/embedded/web/spring-petclinic/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-embedded-web</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_17_maven/em/external/grpc/pom.xml
+++ b/jdk_17_maven/em/external/grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-external-grpc</artifactId>

--- a/jdk_17_maven/em/external/grpc/signal-registration/pom.xml
+++ b/jdk_17_maven/em/external/grpc/signal-registration/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_17_maven/em/external/pom.xml
+++ b/jdk_17_maven/em/external/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-external</artifactId>

--- a/jdk_17_maven/em/external/rest/familie-ba-sak/pom.xml
+++ b/jdk_17_maven/em/external/rest/familie-ba-sak/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-external-rest-familie-ba-sak</artifactId>

--- a/jdk_17_maven/em/external/rest/pom.xml
+++ b/jdk_17_maven/em/external/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-external-rest</artifactId>

--- a/jdk_17_maven/em/external/web/pom.xml
+++ b/jdk_17_maven/em/external/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em-external-web</artifactId>

--- a/jdk_17_maven/em/external/web/spring-petclinic/pom.xml
+++ b/jdk_17_maven/em/external/web/spring-petclinic/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17-em-external-web</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_17_maven/em/pom.xml
+++ b/jdk_17_maven/em/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-jdk17</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-jdk17-em</artifactId>

--- a/jdk_17_maven/pom.xml
+++ b/jdk_17_maven/pom.xml
@@ -9,7 +9,7 @@
         To change version in all modules, use:
         mvn versions:set -DnewVersion=a.b.c
      -->
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <inceptionYear>2017</inceptionYear>
     <name>EvoMaster Benchmark (EMB)</name>
@@ -47,7 +47,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <evomaster-version>3.1.0</evomaster-version>
+        <evomaster-version>3.1.1-SNAPSHOT</evomaster-version>
     </properties>
 
     <build>

--- a/jdk_8_maven/cs/graphql/graphql-ncs/pom.xml
+++ b/jdk_8_maven/cs/graphql/graphql-ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/graphql/graphql-scs/pom.xml
+++ b/jdk_8_maven/cs/graphql/graphql-scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/graphql/pom.xml
+++ b/jdk_8_maven/cs/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-graphql</artifactId>

--- a/jdk_8_maven/cs/pom.xml
+++ b/jdk_8_maven/cs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs</artifactId>

--- a/jdk_8_maven/cs/rest-gui/ocvn/pom.xml
+++ b/jdk_8_maven/cs/rest-gui/ocvn/pom.xml
@@ -84,6 +84,11 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>maven.restlet.org</id>
+            <name>maven.restlet.org</name>
+            <url>https://maven.restlet.talend.com</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>

--- a/jdk_8_maven/cs/rest-gui/pom.xml
+++ b/jdk_8_maven/cs/rest-gui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest-gui</artifactId>

--- a/jdk_8_maven/cs/rest/artificial/ncs/pom.xml
+++ b/jdk_8_maven/cs/rest/artificial/ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs-rest-artificial</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest-artificial-ncs</artifactId>

--- a/jdk_8_maven/cs/rest/artificial/news/pom.xml
+++ b/jdk_8_maven/cs/rest/artificial/news/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs-rest-artificial</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/jdk_8_maven/cs/rest/artificial/pom.xml
+++ b/jdk_8_maven/cs/rest/artificial/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest-artificial</artifactId>

--- a/jdk_8_maven/cs/rest/artificial/scs/pom.xml
+++ b/jdk_8_maven/cs/rest/artificial/scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs-rest-artificial</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest-artificial-scs</artifactId>

--- a/jdk_8_maven/cs/rest/original/pom.xml
+++ b/jdk_8_maven/cs/rest/original/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest-original</artifactId>

--- a/jdk_8_maven/cs/rest/pom.xml
+++ b/jdk_8_maven/cs/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-cs</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-cs-rest</artifactId>

--- a/jdk_8_maven/cs/rpc/grpc/artificial/grpc-ncs/pom.xml
+++ b/jdk_8_maven/cs/rpc/grpc/artificial/grpc-ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-grpc-artificial</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/grpc/artificial/grpc-scs/pom.xml
+++ b/jdk_8_maven/cs/rpc/grpc/artificial/grpc-scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-grpc-artificial</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/grpc/artificial/pom.xml
+++ b/jdk_8_maven/cs/rpc/grpc/artificial/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-grpc</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/grpc/pom.xml
+++ b/jdk_8_maven/cs/rpc/grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/pom.xml
+++ b/jdk_8_maven/cs/rpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/thrift/artificial/pom.xml
+++ b/jdk_8_maven/cs/rpc/thrift/artificial/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-thrift</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/thrift/artificial/thrift-ncs/pom.xml
+++ b/jdk_8_maven/cs/rpc/thrift/artificial/thrift-ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-thrift-artificial</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/thrift/artificial/thrift-scs/pom.xml
+++ b/jdk_8_maven/cs/rpc/thrift/artificial/thrift-scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc-thrift-artificial</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/cs/rpc/thrift/pom.xml
+++ b/jdk_8_maven/cs/rpc/thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-cs-rpc</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/embedded/graphql/graphql-ncs/pom.xml
+++ b/jdk_8_maven/em/embedded/graphql/graphql-ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-embedded-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/embedded/graphql/graphql-scs/pom.xml
+++ b/jdk_8_maven/em/embedded/graphql/graphql-scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-embedded-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/embedded/graphql/petclinic-graphql/pom.xml
+++ b/jdk_8_maven/em/embedded/graphql/petclinic-graphql/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-graphql</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/graphql/pom.xml
+++ b/jdk_8_maven/em/embedded/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded-graphql</artifactId>

--- a/jdk_8_maven/em/embedded/grpc/ncs/pom.xml
+++ b/jdk_8_maven/em/embedded/grpc/ncs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded-grpc-ncs</artifactId>

--- a/jdk_8_maven/em/embedded/grpc/pom.xml
+++ b/jdk_8_maven/em/embedded/grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded-grpc</artifactId>

--- a/jdk_8_maven/em/embedded/grpc/scs/pom.xml
+++ b/jdk_8_maven/em/embedded/grpc/scs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded-grpc-scs</artifactId>

--- a/jdk_8_maven/em/embedded/pom.xml
+++ b/jdk_8_maven/em/embedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded</artifactId>

--- a/jdk_8_maven/em/embedded/rest/catwatch/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/catwatch/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/features-service/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/features-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/genome-nexus/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/genome-nexus/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>

--- a/jdk_8_maven/em/embedded/rest/gestaohospital/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/gestaohospital/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/languagetool/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/languagetool/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/ncs/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/ncs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/news/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/news/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/ocvn/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/ocvn/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>

--- a/jdk_8_maven/em/embedded/rest/proxyprint/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/proxyprint/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/restcountries/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/restcountries/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/scout-api/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/scout-api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/scs/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/scs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/embedded/rest/session-service/pom.xml
+++ b/jdk_8_maven/em/embedded/rest/session-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-embedded-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jdk_8_maven/em/embedded/thrift/ncs/pom.xml
+++ b/jdk_8_maven/em/embedded/thrift/ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-embedded-thrift</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/embedded/thrift/pom.xml
+++ b/jdk_8_maven/em/embedded/thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-embedded</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/embedded/thrift/scs/pom.xml
+++ b/jdk_8_maven/em/embedded/thrift/scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-embedded-thrift</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/external/graphql/graphql-ncs/pom.xml
+++ b/jdk_8_maven/em/external/graphql/graphql-ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-external-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/external/graphql/graphql-scs/pom.xml
+++ b/jdk_8_maven/em/external/graphql/graphql-scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-external-graphql</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/external/graphql/petclinic-graphql/pom.xml
+++ b/jdk_8_maven/em/external/graphql/petclinic-graphql/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-graphql</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/graphql/pom.xml
+++ b/jdk_8_maven/em/external/graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external-graphql</artifactId>

--- a/jdk_8_maven/em/external/grpc/ncs/pom.xml
+++ b/jdk_8_maven/em/external/grpc/ncs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external-grpc-ncs</artifactId>

--- a/jdk_8_maven/em/external/grpc/pom.xml
+++ b/jdk_8_maven/em/external/grpc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external-grpc</artifactId>

--- a/jdk_8_maven/em/external/grpc/scs/pom.xml
+++ b/jdk_8_maven/em/external/grpc/scs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-grpc</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external-grpc-scs</artifactId>

--- a/jdk_8_maven/em/external/pom.xml
+++ b/jdk_8_maven/em/external/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external</artifactId>

--- a/jdk_8_maven/em/external/rest/catwatch/pom.xml
+++ b/jdk_8_maven/em/external/rest/catwatch/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/features-service/pom.xml
+++ b/jdk_8_maven/em/external/rest/features-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/genome-nexus/pom.xml
+++ b/jdk_8_maven/em/external/rest/genome-nexus/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/gestaohospital/pom.xml
+++ b/jdk_8_maven/em/external/rest/gestaohospital/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jdk_8_maven/em/external/rest/ind0/pom.xml
+++ b/jdk_8_maven/em/external/rest/ind0/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_8_maven/em/external/rest/languagetool/pom.xml
+++ b/jdk_8_maven/em/external/rest/languagetool/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/ncs/pom.xml
+++ b/jdk_8_maven/em/external/rest/ncs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/news/pom.xml
+++ b/jdk_8_maven/em/external/rest/news/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/ocvn/pom.xml
+++ b/jdk_8_maven/em/external/rest/ocvn/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/jdk_8_maven/em/external/rest/pom.xml
+++ b/jdk_8_maven/em/external/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em-external-rest</artifactId>

--- a/jdk_8_maven/em/external/rest/proxyprint/pom.xml
+++ b/jdk_8_maven/em/external/rest/proxyprint/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jdk_8_maven/em/external/rest/restcountries/pom.xml
+++ b/jdk_8_maven/em/external/rest/restcountries/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/jdk_8_maven/em/external/rest/scout-api/pom.xml
+++ b/jdk_8_maven/em/external/rest/scout-api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/scs/pom.xml
+++ b/jdk_8_maven/em/external/rest/scs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/rest/session-service/pom.xml
+++ b/jdk_8_maven/em/external/rest/session-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark-em-external-rest</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
 

--- a/jdk_8_maven/em/external/thrift/ncs/pom.xml
+++ b/jdk_8_maven/em/external/thrift/ncs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-external-thrift</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/external/thrift/pom.xml
+++ b/jdk_8_maven/em/external/thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-external</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/external/thrift/scs/pom.xml
+++ b/jdk_8_maven/em/external/thrift/scs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>evomaster-benchmark-em-external-thrift</artifactId>
         <groupId>org.evomaster</groupId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdk_8_maven/em/pom.xml
+++ b/jdk_8_maven/em/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.evomaster</groupId>
         <artifactId>evomaster-benchmark</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>evomaster-benchmark-em</artifactId>

--- a/jdk_8_maven/pom.xml
+++ b/jdk_8_maven/pom.xml
@@ -9,7 +9,7 @@
         To change version in all modules, use:
         mvn versions:set -DnewVersion=a.b.c
      -->
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <inceptionYear>2017</inceptionYear>
     <name>EvoMaster Benchmark (EMB)</name>
@@ -47,7 +47,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <evomaster-version>3.1.0</evomaster-version>
+        <evomaster-version>3.1.1-SNAPSHOT</evomaster-version>
     </properties>
 
     <build>

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -29,12 +29,24 @@ def checkMavenVersion():
     match = re.search(MAVEN_VERSION_REGEX, mvn_path)
     if match == None:
         print("\nCannot determine mvn version from its path location: " + mvn_path)
-#        might happen depending on installation path... instead of crashing immediately,
-#        we try to build, as it might be the correct version... if not, it will fail anyway
-#  TODO ideally, should rather use "mvn -v" to determine the version number...
-#  although it would be bit tricky to implement (so not super important)
-        return True
-#         exit(1)
+
+        # use mcn -v
+        print("\nTrying mvn -v to retrieve the version")
+
+        version_res = run([mvn_path, "-v"], capture_output=True, text=True)
+        result_out = version_res.stdout.strip()
+        match = re.search(MAVEN_VERSION_REGEX, result_out)
+
+        if match == None:
+            print("\nVersion could not be retrieved with mvn -v command")
+
+            #        might happen depending on installation path... instead of crashing immediately,
+            #        we try to build, as it might be the correct version... if not, it will fail anyway
+            #  TODO ideally, should rather use "mvn -v" to determine the version number...
+            #  although it would be bit tricky to implement (so not super important)
+            return True
+
+        #         exit(1)
 
     mvn_txt = match.group()
     mvn_version = mvn_txt.split(".")

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -250,6 +250,9 @@ def build_jdk_11_gradle():
     command = "gradlew"
 
     if platform.system() == "Darwin":
+        # make sure gradlew command is executable
+        os.system("chmod +x " + os.getcwd() + "/" + folder + "/gradlew")
+
         command = "./gradlew"
 
     gradleres = run([command, "build", "-x", "test"], shell=SHELL, cwd=os.path.join(PROJ_LOCATION, folder),
@@ -275,6 +278,10 @@ def build_jdk_17_gradle():
     command = "gradlew"
 
     if platform.system() == "Darwin":
+
+        # make sure gradlew command is executable
+        os.system("chmod +x " + os.getcwd() + "/" + folder + "/gradlew")
+
         command = "./gradlew"
 
     gradleres = run([command, "build", "-x", "test"], shell=SHELL, cwd=os.path.join(PROJ_LOCATION, folder),

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-EVOMASTER_VERSION = "3.1.0"
+EVOMASTER_VERSION = "3.1.1-SNAPSHOT"
 
 import sys
 import os


### PR DESCRIPTION
mvn -v command is executed to get the mvn version

Added some dependencies to familie-ba-sak and ocvn to make sure maven can resolve those dependencies.

Added one line to make sure gradlew file is executable before running the ./gradlew command in Mac